### PR TITLE
fix: 黑暗之怖工业区，冶金工人，民用工厂修复

### DIFF
--- a/common/buildings/ethic_manufacturing_buildings.txt
+++ b/common/buildings/ethic_manufacturing_buildings.txt
@@ -701,17 +701,8 @@ building_factory_1 = {
 		}
 	}
 
-	triggered_planet_modifier = {
-		potential = {
-			exists = owner
-			owner = {
-				is_regular_empire = yes
-			}
-		}
-		modifier = {
-			job_artisan_specialist_add = @b1_jobs
-			job_environmental_pollution_caused_mult = 0.05
-		}
+	planet_modifier = {
+		job_environmental_pollution_caused_mult = 0.05
 	}
 
 	triggered_planet_modifier = {
@@ -723,7 +714,7 @@ building_factory_1 = {
 			}
 		}
 		modifier = {
-			job_artisan_add = @b1_jobs
+			job_artisan_specialist_add = @b1_jobs
 		}
 	}
 

--- a/common/districts/00_urban_districts.txt
+++ b/common/districts/00_urban_districts.txt
@@ -144,7 +144,6 @@ district_crashed_slaver_ship = {
 }
 
 # 城市区划
-@city_cost = 500
 district_city = {
 	base_buildtime = 480
 	is_capped_by_modifier = no
@@ -224,30 +223,6 @@ district_city = {
 		planet_housing_add = 4
 		planet_max_buildings_add = 1
 		planet_carry_cap_add = 5
-	}
-	triggered_planet_modifier = {
-		potential = {
-			exists = owner
-			owner = {
-				is_regular_empire = yes
-				is_capitalism = no
-			}
-		}
-		modifier = {
-			job_clerk_add = 1
-		}
-	}
-	triggered_planet_modifier = {
-		potential = {
-			exists = owner
-			owner = {
-				is_regular_empire = yes
-				is_capitalism = yes
-			}
-		}
-		modifier = {
-			job_clerk_add = 1
-		}
 	}
 	triggered_planet_modifier = {
 		potential = {
@@ -913,21 +888,6 @@ district_industrial = {
 		potential = {
 			exists = owner
 			owner = {
-				OR = {
-					is_regular_empire = yes
-					has_origin = origin_fear_of_the_dark
-				}
-			}
-		}
-		modifier = {
-			job_artisan_add = 1
-			job_foundry_add = 1
-		}
-	}
-	triggered_planet_modifier = {
-		potential = {
-			exists = owner
-			owner = {
 				has_tradition = tr_harmony_the_greater_good
 			}
 			has_global_flag = ideological_revolution
@@ -940,7 +900,10 @@ district_industrial = {
 		potential = {
 			exists = owner
 			owner = {
-				is_regular_empire = yes
+				OR = {
+					is_regular_empire = yes
+					has_origin = origin_fear_of_the_dark
+				}
 				NOT = {
 					has_origin = origin_zarqlanism_idea
 				}

--- a/common/scripted_loc/ethic_rebuild_scripted_loc.txt
+++ b/common/scripted_loc/ethic_rebuild_scripted_loc.txt
@@ -602,9 +602,9 @@ defined_text = {
 			is_scope_valid = yes
 			is_catalytic_empire = yes
 		}
-		localization_key = job_alloyproducer_upkeep_minerals
+		localization_key = job_alloyproducer_upkeep_food
 	}
-	default = job_alloyproducer_upkeep_food
+	default = job_alloyproducer_upkeep_minerals
 }
 
 defined_text = {
@@ -614,7 +614,7 @@ defined_text = {
 			is_scope_valid = yes
 			is_catalytic_empire = yes
 		}
-		localization_key = job_alloyproducer_upkeep_minerals
+		localization_key = job_alloyproducer_upkeep_food
 	}
-	default = job_alloyproducer_upkeep_food
+	default = job_alloyproducer_upkeep_minerals
 }


### PR DESCRIPTION
[bug fix] 工业区：加入黑暗之怖起源trigger使其与原版同步
[bug fix] 冶金工人维护费描述错误
[bug fix] 民用工厂：上次pull之后没仔细看导致一级民用工厂会有双倍员工